### PR TITLE
Feat: Added support for Darwin.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     name: asdf plugin test
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -35,6 +35,8 @@ download_release() {
   local version="$1"
   local filename="$2"
 
+  platform=`uname -s`
+
   case "$(uname -s)" in
     Linux*) platform=linux ;;
   esac
@@ -44,7 +46,7 @@ download_release() {
     x86_64) arch=x86_64 ;;
   esac
 
-  echo >&2 "* Downloading gum release $version..."
+  echo >&2 "* Downloading gum release $version for $platform with architecture $arch..."
 
   local ext url
   for ext in tar.gz zip; do


### PR DESCRIPTION
Previously the platform variable was not being set on any platform other than linux. By defaulting to the currently running platform we ensure that the script does not crash. With this change, as a side-effect, we've added support for macos.