### PR TITLE
enable installing on m1 macs by adding arm64 arch

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -44,6 +44,7 @@ download_release() {
   case "$(uname -m)" in
     aarch64) arch=aarch64 ;;
     x86_64) arch=x86_64 ;;
+    arm64) arch=arm64 ;;
   esac
 
   echo >&2 "* Downloading gum release $version for $platform with architecture $arch..."


### PR DESCRIPTION
This enables installation of gum on M1 Macs.